### PR TITLE
URL Cleanup

### DIFF
--- a/src/it/scala/io/micrometer/spring/perf/GatlingFunSpecExampleIT.scala
+++ b/src/it/scala/io/micrometer/spring/perf/GatlingFunSpecExampleIT.scala
@@ -7,7 +7,7 @@ import GatlingFunSpecExampleIT._
 
 class GatlingFunSpecExampleIT extends GatlingHttpFunSpec {
 
-  val baseURL = "http://example.com"
+  val baseURL = "https://example.com"
   override def httpConf = super.httpConf.header("MyHeader", "MyValue")
 
   spec {

--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -68,7 +68,7 @@ gatling {
     #expirePerUserCacheMaxCapacity = 200       # Per virtual user cache size for permanent 'Expire' headers, set to 0 to disable
     #lastModifiedPerUserCacheMaxCapacity = 200 # Per virtual user cache size for permanent 'Last-Modified' headers, set to 0 to disable
     #etagPerUserCacheMaxCapacity = 200         # Per virtual user cache size for permanent ETag headers, set to 0 to disable
-    #warmUpUrl = "http://gatling.io"           # The URL to use to warm-up the HTTP stack (blank means disabled)
+    #warmUpUrl = "https://gatling.io"           # The URL to use to warm-up the HTTP stack (blank means disabled)
     #enableGA = true                           # Very light Google Analytics, please support
     ssl {
       trustStore {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://example.com with 1 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* http://gatling.io with 1 occurrences migrated to:  
  https://gatling.io ([https](https://gatling.io) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences